### PR TITLE
Update website link in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ NetworkModules(test_srt)
 
 ## More
 
-More info about Pando can be found on our [website](https://quadbiolab.github.io/Pando/). There you can find an API reference and a number of tutorial vignettes that give an introduction on how to use Pando most effectively.  
+More info about Pando can be found on our [website](https://quadbio.github.io/Pando/). There you can find an API reference and a number of tutorial vignettes that give an introduction on how to use Pando most effectively.  
 
 
 


### PR DESCRIPTION
Transfering the repo over to the lab organization account unfortunately broke the link to github pages. All links to the github repo itself are automatically redirected, but unfortunately, this does not hold for links to github pages. This just updates the link in the readme from `https://quadbiolab.github.io/Pando/`  to `https://quadbio.github.io/Pando/`